### PR TITLE
Add Next.js 14 scaffold

### DIFF
--- a/next/.env.example
+++ b/next/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_SITE_URL=https://bera.com

--- a/next/.eslintrc.js
+++ b/next/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  extends: ['next', 'next/core-web-vitals', 'prettier'],
+  rules: {}
+};

--- a/next/.github/workflows/ci.yml
+++ b/next/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test -- --runInBand
+      - run: npm run build

--- a/next/.husky/_/husky.sh
+++ b/next/.husky/_/husky.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ -z "$husky_skip_init" ]; then
+  debug() {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky: $*"
+  }
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+  readonly husky_dir="$(dirname "$0")/.."
+  debug "husky_dir: $husky_dir"
+  readonly git_params="$(printf '%q ' "$@")"
+  if [ -f "$husky_dir/husky.sh" ]; then
+    . "$husky_dir/husky.sh"
+  else
+    debug "running npx --no-install husky-run $hook_name $git_params"
+    npx --no-install husky-run "$hook_name" $git_params
+  fi
+fi

--- a/next/.husky/pre-commit
+++ b/next/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run lint

--- a/next/.prettierrc
+++ b/next/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/next/README.md
+++ b/next/README.md
@@ -1,0 +1,14 @@
+# BERA Clothing
+
+Proyecto de e-commerce basado en Next.js 14.
+
+## Scripts
+- `npm run dev` inicia entorno de desarrollo
+- `npm run build` crea build de producción
+- `npm run start` sirve la app
+
+## Variables de entorno
+- `NEXT_PUBLIC_SITE_URL` URL pública del sitio
+
+## Despliegue
+Configurar variables y ejecutar `npm run build` seguido de `npm run start`. Para regenerar páginas estáticas se pueden usar webhooks desde el CMS.

--- a/next/jest.config.js
+++ b/next/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  }
+};

--- a/next/next-env.d.ts
+++ b/next/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next/next-sitemap.js
+++ b/next/next-sitemap.js
@@ -1,0 +1,5 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+  siteUrl: process.env.NEXT_PUBLIC_SITE_URL || 'https://bera.com',
+  generateRobotsTxt: true
+};

--- a/next/next.config.js
+++ b/next/next.config.js
@@ -1,0 +1,12 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true,
+    typedRoutes: true
+  },
+  images: {
+    domains: ['images.example.com']
+  }
+};
+
+module.exports = nextConfig;

--- a/next/package.json
+++ b/next/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "bera-clothing",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "jest",
+    "e2e": "playwright test"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@headlessui/react": "^1.7.15",
+    "@heroicons/react": "^2.1.1",
+    "clsx": "^2.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.14",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "^14.1.0",
+    "prettier": "^3.0.3",
+    "jest": "^29.6.1",
+    "@testing-library/react": "^14.0.0",
+    "playwright": "^1.39.0",
+    "husky": "^8.0.0"
+  }
+}

--- a/next/playwright.config.ts
+++ b/next/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  webServer: {
+    command: 'npm run start',
+    port: 3000
+  },
+  use: {
+    baseURL: 'http://localhost:3000'
+  }
+});

--- a/next/postcss.config.js
+++ b/next/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/next/public/manifest.json
+++ b/next/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "BERA Clothing",
+  "short_name": "BERA",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#111827",
+  "icons": [
+    {
+      "src": "/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/next/public/service-worker.js
+++ b/next/public/service-worker.js
@@ -1,0 +1,23 @@
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(clients.claim());
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      return (
+        cached ||
+        fetch(event.request).then((response) => {
+          const copy = response.clone();
+          caches.open('bera').then((cache) => cache.put(event.request, copy));
+          return response;
+        })
+      );
+    })
+  );
+});

--- a/next/src/__tests__/basic.test.tsx
+++ b/next/src/__tests__/basic.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Home from '../app/page';
+
+describe('Home', () => {
+  it('renders hero', () => {
+    render(<Home />);
+    expect(screen.getByText('Nueva temporada')).toBeInTheDocument();
+  });
+});

--- a/next/src/app/account/page.tsx
+++ b/next/src/app/account/page.tsx
@@ -1,0 +1,8 @@
+export default function AccountPage() {
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Mi cuenta</h1>
+      <p>Historial de pedidos próximamente.</p>
+    </div>
+  );
+}

--- a/next/src/app/cart/page.tsx
+++ b/next/src/app/cart/page.tsx
@@ -1,0 +1,8 @@
+export default function CartPage() {
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Carrito</h1>
+      <p>Tu carrito está vacío.</p>
+    </div>
+  );
+}

--- a/next/src/app/checkout/page.tsx
+++ b/next/src/app/checkout/page.tsx
@@ -1,0 +1,8 @@
+export default function CheckoutPage() {
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Checkout</h1>
+      <p>Funcionalidad de pago próximamente.</p>
+    </div>
+  );
+}

--- a/next/src/app/error.tsx
+++ b/next/src/app/error.tsx
@@ -1,0 +1,9 @@
+'use client';
+export default function Error({ error }: { error: Error }) {
+  return (
+    <div className="h-screen flex items-center justify-center">
+      <h1 className="text-2xl font-bold">Algo salió mal</h1>
+      <p className="mt-2">{error.message}</p>
+    </div>
+  );
+}

--- a/next/src/app/globals.css
+++ b/next/src/app/globals.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+html.dark {
+  --tw-bg-opacity: 1;
+  background-color: rgb(17 24 39 / var(--tw-bg-opacity));
+  color: white;
+}

--- a/next/src/app/layout.tsx
+++ b/next/src/app/layout.tsx
@@ -1,0 +1,43 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
+import { ReactNode } from 'react';
+import Link from 'next/link';
+import DarkModeToggle from '../components/DarkModeToggle';
+
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
+
+export const metadata: Metadata = {
+  title: {
+    default: 'BERA Clothing',
+    template: '%s | BERA Clothing'
+  },
+  description: 'Tienda online de indumentaria urbana.'
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="es" className={inter.variable}>
+      <body className="min-h-screen font-sans antialiased bg-white text-gray-900">
+        <header className="border-b sticky top-0 bg-white z-50">
+          <nav className="max-w-7xl mx-auto flex items-center justify-between p-4">
+            <Link href="/" className="text-lg font-bold">BERA</Link>
+            <div className="flex items-center gap-4">
+              <Link href="/products" className="text-sm">Catálogo</Link>
+              <DarkModeToggle />
+            </div>
+          </nav>
+        </header>
+        {children}
+        <footer className="border-t mt-10 p-4 text-center text-sm">
+          &copy; {new Date().getFullYear()} BERA Clothing.
+        </footer>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `if('serviceWorker' in navigator){window.addEventListener('load',()=>{navigator.serviceWorker.register('/service-worker.js');});}`
+          }}
+        />
+      </body>
+    </html>
+  );
+}

--- a/next/src/app/not-found.tsx
+++ b/next/src/app/not-found.tsx
@@ -1,0 +1,7 @@
+export default function NotFound() {
+  return (
+    <div className="h-screen flex items-center justify-center">
+      <h1 className="text-2xl font-bold">404 - Página no encontrada</h1>
+    </div>
+  );
+}

--- a/next/src/app/offers/page.tsx
+++ b/next/src/app/offers/page.tsx
@@ -1,0 +1,8 @@
+export default function OffersPage() {
+  return (
+    <div className="max-w-7xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Ofertas</h1>
+      <p>Próximamente listaremos aquí las mejores ofertas.</p>
+    </div>
+  );
+}

--- a/next/src/app/page.tsx
+++ b/next/src/app/page.tsx
@@ -1,0 +1,14 @@
+import Hero from '../components/Hero';
+import ProductCarousel from '../components/ProductCarousel';
+
+export default function Home() {
+  return (
+    <main className="space-y-12 p-4">
+      <Hero />
+      <section className="max-w-7xl mx-auto">
+        <h2 className="text-xl font-semibold mb-4">Nuevos ingresos</h2>
+        <ProductCarousel type="new" />
+      </section>
+    </main>
+  );
+}

--- a/next/src/app/product/[id]/page.tsx
+++ b/next/src/app/product/[id]/page.tsx
@@ -1,0 +1,29 @@
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+
+const products = {
+  '1': {
+    name: 'Remera básica',
+    price: 10000,
+    image: '/products/shirt.jpg',
+    description: 'Remera de algodón premium.'
+  }
+};
+
+export default function ProductPage({ params }: { params: { id: string } }) {
+  const product = products[params.id];
+  if (!product) return notFound();
+  return (
+    <div className="max-w-4xl mx-auto p-4 grid md:grid-cols-2 gap-6">
+      <div className="relative w-full h-80">
+        <Image src={product.image} alt={product.name} fill className="object-cover" />
+      </div>
+      <div>
+        <h1 className="text-2xl font-bold">{product.name}</h1>
+        <p className="mt-2">{product.description}</p>
+        <p className="mt-4 text-xl">${product.price}</p>
+        <button className="mt-4 bg-black text-white px-4 py-2">Agregar al carrito</button>
+      </div>
+    </div>
+  );
+}

--- a/next/src/app/products/page.tsx
+++ b/next/src/app/products/page.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+import Image from 'next/image';
+
+const products = [
+  {
+    id: '1',
+    name: 'Remera básica',
+    price: 10000,
+    image: '/products/shirt.jpg'
+  }
+];
+
+export default function ProductsPage() {
+  return (
+    <div className="max-w-7xl mx-auto p-4 grid grid-cols-2 md:grid-cols-4 gap-6">
+      {products.map((p) => (
+        <Link key={p.id} href={`/product/${p.id}`} className="border p-2">
+          <div className="relative w-full h-48">
+            <Image src={p.image} alt={p.name} fill className="object-cover" />
+          </div>
+          <h3 className="mt-2 text-sm font-medium">{p.name}</h3>
+          <p className="text-sm">${p.price}</p>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/next/src/app/size-guide/page.tsx
+++ b/next/src/app/size-guide/page.tsx
@@ -1,0 +1,8 @@
+export default function SizeGuidePage() {
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Guía de Talles</h1>
+      <p>Tabla de medidas por prenda.</p>
+    </div>
+  );
+}

--- a/next/src/components/Button.tsx
+++ b/next/src/components/Button.tsx
@@ -1,0 +1,14 @@
+import { ButtonHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export default function Button({ className, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      {...props}
+      className={clsx(
+        'px-4 py-2 rounded bg-primary text-white hover:bg-primary-light focus:outline-none focus:ring-2 focus:ring-primary-dark',
+        className
+      )}
+    />
+  );
+}

--- a/next/src/components/DarkModeToggle.tsx
+++ b/next/src/components/DarkModeToggle.tsx
@@ -1,0 +1,19 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function DarkModeToggle() {
+  const [enabled, setEnabled] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    setEnabled(localStorage.theme === 'dark' || mq.matches);
+  }, []);
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', enabled);
+    localStorage.theme = enabled ? 'dark' : 'light';
+  }, [enabled]);
+  return (
+    <button onClick={() => setEnabled(!enabled)} aria-label="Toggle dark mode" className="text-sm">
+      {enabled ? '🌙' : '☀️'}
+    </button>
+  );
+}

--- a/next/src/components/Hero.tsx
+++ b/next/src/components/Hero.tsx
@@ -1,0 +1,18 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+export default function Hero() {
+  return (
+    <div className="relative h-64 sm:h-96 w-full overflow-hidden rounded-lg">
+      <Image src="/hero.jpg" alt="Campaña" fill priority className="object-cover" />
+      <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-center text-white p-4">
+        <h1 className="text-3xl font-bold">Nueva temporada</h1>
+        <p className="mt-2 max-w-md">Descubrí las últimas tendencias en indumentaria urbana.</p>
+        <div className="mt-4 flex gap-2">
+          <Link href="/products" className="bg-white text-black px-4 py-2 text-sm font-semibold rounded">Comprar ahora</Link>
+          <Link href="/offers" className="border border-white px-4 py-2 text-sm rounded">Ver ofertas</Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/next/src/components/Input.tsx
+++ b/next/src/components/Input.tsx
@@ -1,0 +1,14 @@
+import { InputHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export default function Input({ className, ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      {...props}
+      className={clsx(
+        'border rounded p-2 w-full focus:outline-none focus:ring-2 focus:ring-primary',
+        className
+      )}
+    />
+  );
+}

--- a/next/src/components/ProductCarousel.tsx
+++ b/next/src/components/ProductCarousel.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import Image from 'next/image';
+
+interface Product {
+  id: string;
+  name: string;
+  price: number;
+  image: string;
+}
+
+const products: Product[] = [
+  {
+    id: '1',
+    name: 'Remera básica',
+    price: 10000,
+    image: '/products/shirt.jpg'
+  }
+];
+
+export default function ProductCarousel({ type }: { type: string }) {
+  return (
+    <div className="flex overflow-x-auto gap-4 snap-x">
+      {products.map((p) => (
+        <Link
+          href={`/product/${p.id}`}
+          key={p.id}
+          className="min-w-[200px] snap-start"
+        >
+          <div className="relative h-48 w-48">
+            <Image src={p.image} alt={p.name} fill className="object-cover" />
+          </div>
+          <h3 className="mt-2 text-sm font-medium">{p.name}</h3>
+          <p className="text-sm">${p.price}</p>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/next/src/lib/analytics.ts
+++ b/next/src/lib/analytics.ts
@@ -1,0 +1,6 @@
+export function gaEvent(action: string, params: Record<string, unknown>) {
+  if (typeof window === 'undefined') return;
+  window.gtag?.('event', action, params);
+}
+
+export const GA_MEASUREMENT_ID = 'G-XXXXXXXX';

--- a/next/src/lib/jsonld.ts
+++ b/next/src/lib/jsonld.ts
@@ -1,0 +1,16 @@
+export function productLD({ id, name, description, price, image }: { id: string; name: string; description: string; price: number; image: string }) {
+  return {
+    '@context': 'https://schema.org/',
+    '@type': 'Product',
+    name,
+    image,
+    description,
+    sku: id,
+    offers: {
+      '@type': 'Offer',
+      priceCurrency: 'ARS',
+      price,
+      availability: 'https://schema.org/InStock'
+    }
+  };
+}

--- a/next/tailwind.config.ts
+++ b/next/tailwind.config.ts
@@ -1,0 +1,22 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: [
+    './src/**/*.{ts,tsx,mdx}'
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['InterVariable', 'sans-serif']
+      },
+      colors: {
+        primary: {
+          DEFAULT: '#111827',
+          light: '#374151',
+          dark: '#000000'
+        }
+      }
+    }
+  },
+  plugins: [require('@tailwindcss/forms')]
+} satisfies Config;

--- a/next/tsconfig.json
+++ b/next/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a new Next.js 14 project with TypeScript and Tailwind
- include basic pages (home, catalog, product, cart, checkout, account, offers, size guide)
- implement layout with dark mode toggle and service worker registration
- add reusable components and simple test setup
- add CI workflow and configuration files

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883bd30b54c8321beb17c9f322e62c2