### PR TITLE
Rebrand site to Viviana Varacca Boutique

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -12,10 +12,10 @@
   <meta charset="UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <title>BERA clothing – Contacto</title>
-  <meta name="description" content="Hablemos. Coordiná entregas, armá tus combos BERA y resolvé envíos por WhatsApp o formulario." />
+  <title>Viviana Varacca Boutique – Contacto</title>
+  <meta name="description" content="Hablemos. Coordiná entregas, armá tus combos Viviana Varacca Boutique y resolvé envíos por WhatsApp o formulario." />
   <meta name="theme-color" content="#e91e63">
-  <link rel="canonical" href="https://www.beraclothing.store/contacto.html" />
+  <link rel="canonical" href="https://www.vivianavaraccaboutique.com/contacto.html" />
   <meta name="color-scheme" content="light dark" />
   <meta name="format-detection" content="telephone=no,address=no,email=no" />
   <link rel="icon" href="assets/images/favicon.ico" />
@@ -67,14 +67,14 @@
       <div class="site-branding">
         <a href="index.html" class="logo-link" aria-label="Inicio">
           <div class="logo-wrap">
-            <img src="assets/images/logoo.jpeg" alt="Logo BERA clothing" class="logo" width="60" height="60" decoding="async" fetchpriority="high" />
+            <img src="assets/images/logoo.jpeg" alt="Logo Viviana Varacca Boutique" class="logo" width="60" height="60" decoding="async" fetchpriority="high" />
           </div>
         </a>
-        <div class="site-title" aria-label="BERA CLOTHING">
-          <span class="title-bera">BERA</span>
-          <span class="title-clothing">CLOTHING</span>
+        <div class="site-title" aria-label="VIVIANA VARACCA BOUTIQUE">
+          <span class="title-bera">VIVIANA</span>
+          <span class="title-clothing">BOUTIQUE</span>
         </div>
-        <span class="site-tagline">BY FRIAS</span>
+        <span class="site-tagline">VIVIANAVARACCA.BOUTIQUE</span>
       </div>
 
       <button class="hamburger nav-toggle" type="button"
@@ -118,7 +118,7 @@
         </div>
 
         <div class="menu-media">
-          <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener">Instagram</a>
+          <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">Instagram</a>
           <a href="https://wa.me/5491123456789" target="_blank" rel="noopener">WhatsApp</a>
         </div>
       </nav>
@@ -146,7 +146,7 @@
           </div>
         </div>
         <figure class="hero-media">
-          <img src="assets/images/IMG_7232.jpeg" alt="Equipo BERA atendiendo consultas" loading="lazy" decoding="async" />
+          <img src="assets/images/IMG_7232.jpeg" alt="Equipo Viviana Varacca Boutique atendiendo consultas" loading="lazy" decoding="async" />
         </figure>
       </div>
     </section>
@@ -205,7 +205,7 @@
               <svg xmlns="http://www.w3.org/2000/svg" class="icon" viewBox="0 0 24 24"><path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.89 2 1.99 2H20c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/></svg>
               <div>
                 <strong>Mail</strong>
-                <a href="mailto:hola@beraclothing.com">hola@beraclothing.com</a>
+                <a href="mailto:hola@vivianavaraccaboutique.com">hola@vivianavaraccaboutique.com</a>
               </div>
             </li>
             <li>
@@ -219,7 +219,7 @@
           <div class="map-container">
             <iframe
               src="https://www.google.com/maps?q=Calle+10+N+4629+Berazategui+Buenos+Aires&output=embed"
-              title="Mapa: BERA clothing en Berazategui"
+              title="Mapa: Viviana Varacca Boutique en Berazategui"
               loading="lazy"
               allowfullscreen=""
             ></iframe>
@@ -234,7 +234,7 @@
   <footer class="site-footer" role="contentinfo">
     <div class="container footer-inner">
       <p>
-        <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener" class="instagram-icon" aria-label="Instagram">
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener" class="instagram-icon" aria-label="Instagram">
           <img src="assets/images/instaa.png" alt="Instagram" width="28" height="28" loading="lazy" decoding="async">
         </a>
         | Shop online 24/7 | Envíos a todo el país | Berazategui centro
@@ -244,9 +244,9 @@
         <a href="terminos.html">Términos de servicio</a>
       </p>
       By
-        <a href="https://instagram.com/melinaffrias" target="_blank" rel="noopener">@melinaffrias</a> <span>&amp;</span>
-        <a href="https://instagram.com/candelaffrias" target="_blank" rel="noopener">@candelaffrias</a>
-      <p>© 2025 BERA clothing. Todos los derechos reservados.</p>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">@vivianavaracca.boutique</a> <span>&amp;</span>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">@vivianavaracca.boutique</a>
+      <p>© 2025 Viviana Varacca Boutique. Todos los derechos reservados.</p>
     </div>
   </footer>
 
@@ -283,7 +283,7 @@
         <a href="proximamente.html#bodys">Bodys</a>
       </div>
       <div class="collection-social">
-        <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener">Instagram</a>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">Instagram</a>
         <a href="https://wa.me/5491123456789" target="_blank" rel="noopener">WhatsApp</a>
       </div>
     </nav>

--- a/finalizarcompra.html
+++ b/finalizarcompra.html
@@ -18,13 +18,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
     <!-- SEO & Social -->
-    <title>BERA Clothing | Finalizar compra</title>
+    <title>Viviana Varacca Boutique | Finalizar compra</title>
     <meta
       name="description"
-      content="Finalizá tu compra en BERA Clothing: revisá tu pedido y pagá con Mercado Pago o efectivo (10% de descuento). Retiro en local o punto de encuentro."
+      content="Finalizá tu compra en Viviana Varacca Boutique: revisá tu pedido y pagá con Mercado Pago o efectivo (10% de descuento). Retiro en local o punto de encuentro."
     />
     <meta name="theme-color" content="#e91e63" />
-    <link rel="canonical" href="https://www.beraclothing.store/finalizarcompra.html" />
+    <link rel="canonical" href="https://www.vivianavaraccaboutique.com/finalizarcompra.html" />
     <meta name="color-scheme" content="dark light" />
     <meta name="format-detection" content="telephone=no, email=no, address=no" />
     <link rel="icon" href="assets/images/favicon.ico" />
@@ -45,8 +45,8 @@
     {
       "@context": "https://schema.org",
       "@type": "CheckoutPage",
-      "name": "Finalizar compra – BERA Clothing",
-      "url": "https://www.beraclothing.store/finalizarcompra.html"
+      "name": "Finalizar compra – Viviana Varacca Boutique",
+      "url": "https://www.vivianavaraccaboutique.com/finalizarcompra.html"
     }
     </script>
   </head>
@@ -90,14 +90,14 @@
     <div class="site-branding">
   <a href="index.html" class="logo-link" aria-label="Inicio">
     <div class="logo-wrap">
-      <img src="assets/images/logoo.jpeg" alt="Logo BERA clothing" class="logo" width="64" height="64" decoding="async" fetchpriority="high" />
+      <img src="assets/images/logoo.jpeg" alt="Logo Viviana Varacca Boutique" class="logo" width="64" height="64" decoding="async" fetchpriority="high" />
     </div>
   </a>
-  <div class="site-title" aria-label="BERA CLOTHING">
-    <span class="title-bera">BERA</span>
-    <span class="title-clothing">CLOTHING</span>
+  <div class="site-title" aria-label="VIVIANA VARACCA BOUTIQUE">
+    <span class="title-bera">VIVIANA</span>
+    <span class="title-clothing">BOUTIQUE</span>
   </div>
-  <span class="site-tagline">BY FRIAS</span>
+  <span class="site-tagline">VIVIANAVARACCA.BOUTIQUE</span>
 </div>
 
       <button class="hamburger nav-toggle"
@@ -141,7 +141,7 @@
         </div>
 
         <div class="menu-media">
-          <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener">Instagram</a>
+          <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">Instagram</a>
           <a href="https://wa.me/5491123456789" target="_blank" rel="noopener">WhatsApp</a>
         </div>
       </nav>
@@ -163,7 +163,7 @@
         <div class="container hero-shell">
           <div class="hero-content">
             <span class="hero-eyebrow">Checkout seguro</span>
-            <h1 id="hero-title" class="hero-title">Listo para cerrar tu pedido BERA</h1>
+            <h1 id="hero-title" class="hero-title">Listo para cerrar tu pedido Viviana Varacca Boutique</h1>
             <p class="hero-lead">Revisá el resumen, elegí la forma de entrega y confirmá. Te redirigimos a Instagram con el mensaje prearmado para coordinar pago y retiro.</p>
             <div class="hero-badges">
               <span class="hero-badge">10% OFF efectivo</span>
@@ -172,7 +172,7 @@
             </div>
           </div>
           <figure class="hero-media">
-            <img src="assets/images/IMG_7224.jpeg" alt="Caja BERA lista para entregar" loading="lazy" decoding="async" />
+            <img src="assets/images/IMG_7224.jpeg" alt="Caja Viviana Varacca Boutique lista para entregar" loading="lazy" decoding="async" />
           </figure>
         </div>
       </section>
@@ -268,7 +268,7 @@
                   <span>Mercado Pago (precio final sin descuento)</span>
                 </label>
                 <p class="payment-help" aria-live="polite">
-                  Con efectivo aplicamos 10% de descuento sobre el precio final. Con Mercado Pago abonás el precio final sin descuento. Al presionar “Confirmar pedido” te vamos a redirigir a nuestro perfil de Instagram (@beraclothingg). Ya copiamos el resumen para que lo pegues y nos escribas por DM.
+                  Con efectivo aplicamos 10% de descuento sobre el precio final. Con Mercado Pago abonás el precio final sin descuento. Al presionar “Confirmar pedido” te vamos a redirigir a nuestro perfil de Instagram (@vivianavaracca.boutique). Ya copiamos el resumen para que lo pegues y nos escribas por DM.
                 </p>
               </div>
             </fieldset>
@@ -316,7 +316,7 @@
         <div class="pre-dm-modal__content" role="document">
           <h2 id="dm-title" class="pre-dm-title">Vamos a abrir Instagram</h2>
           <p id="dm-instructions" class="pre-dm-body">
-            Ahora te vamos a redirigir a nuestro perfil de Instagram (<strong>@beraclothingg</strong>).
+            Ahora te vamos a redirigir a nuestro perfil de Instagram (<strong>@vivianavaracca.boutique</strong>).
             <br>El resumen de tu pedido ya quedó <strong>copiado</strong>: cuando se abra Instagram, <strong>pegalo</strong> en un DM y tocá enviar.
           </p>
           <div class="dm-preview-wrap">
@@ -341,7 +341,7 @@
       <!-- ========== /PRE-DM INSTAGRAM MODAL (simple) ========== -->
     <noscript>
       <div role="status" style="padding:12px; margin:12px auto; max-width:900px; border:1px solid #ddd; border-radius:8px; background:#fafafa; color:#333">
-        Para finalizar tu compra, escribinos por Instagram a <a href="https://ig.me/m/beraclothingg" rel="noopener" target="_blank">@beraclothingg</a> y contanos los productos de tu carrito.
+        Para finalizar tu compra, escribinos por Instagram a <a href="https://ig.me/m/vivianavaracca.boutique" rel="noopener" target="_blank">@vivianavaracca.boutique</a> y contanos los productos de tu carrito.
       </div>
     </noscript>
     </main>
@@ -350,7 +350,7 @@
     <footer class="site-footer" role="contentinfo">
       <div class="container footer-inner">
       <p>
-        <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener" class="instagram-icon" aria-label="Instagram">
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener" class="instagram-icon" aria-label="Instagram">
           <img src="assets/images/instaa.png" alt="Instagram" width="28" height="28" loading="lazy" decoding="async">
         </a>
         | Shop online 24/7 | Envíos a todo el país | Berazategui centro
@@ -360,9 +360,9 @@
         <a href="terminos.html">Términos de servicio</a>
       </p>
       By
-        <a href="https://instagram.com/melinaffrias" target="_blank" rel="noopener">@melinaffrias</a> <span>&amp;</span>
-        <a href="https://instagram.com/candelaffrias" target="_blank" rel="noopener">@candelaffrias</a>
-      <p>© 2025 BERA clothing. Todos los derechos reservados.</p>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">@vivianavaracca.boutique</a> <span>&amp;</span>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">@vivianavaracca.boutique</a>
+      <p>© 2025 Viviana Varacca Boutique. Todos los derechos reservados.</p>
       </div>
     </footer>
 

--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
   <meta charset="UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <title>BERA clothing – Inicio</title>
-  <meta name="description" content="BERA clothing: moda urbana contemporánea con envíos a todo el país. Descubrí drops semanales directos desde Berazategui." />
+  <title>Viviana Varacca Boutique – Inicio</title>
+  <meta name="description" content="Viviana Varacca Boutique: moda urbana contemporánea con envíos a todo el país. Descubrí drops semanales directos desde Berazategui." />
   <meta name="theme-color" content="#e91e63">
   <meta name="color-scheme" content="light dark" />
   <meta name="format-detection" content="telephone=no" />
@@ -27,20 +27,20 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css" />
   <link rel="stylesheet" href="css/style.css" />
-  <link rel="canonical" href="https://www.beraclothing.store/" />
+  <link rel="canonical" href="https://www.vivianavaraccaboutique.com/" />
 
   <!-- Open Graph -->
   <meta property="og:type" content="website">
-  <meta property="og:title" content="BERA clothing – Moda urbana 24/7">
+  <meta property="og:title" content="Viviana Varacca Boutique – Moda urbana 24/7">
   <meta property="og:description" content="Moda urbana para jóvenes. Envíos a todo el país desde Berazategui centro.">
-  <meta property="og:url" content="https://www.beraclothing.store/">
-  <meta property="og:image" content="https://www.beraclothing.store/assets/og/bera-cover.jpg">
+  <meta property="og:url" content="https://www.vivianavaraccaboutique.com/">
+  <meta property="og:image" content="https://www.vivianavaraccaboutique.com/assets/og/viviana-varacca-cover.jpg">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="BERA clothing – Moda urbana 24/7">
+  <meta name="twitter:title" content="Viviana Varacca Boutique – Moda urbana 24/7">
   <meta name="twitter:description" content="Shop online, envíos a todo el país.">
-  <meta name="twitter:image" content="https://www.beraclothing.store/assets/og/bera-cover.jpg">
+  <meta name="twitter:image" content="https://www.vivianavaraccaboutique.com/assets/og/viviana-varacca-cover.jpg">
 
   <!-- Preload hero para LCP -->
   <link rel="preload" as="image" href="assets/images/IMG_7236.jpeg" fetchpriority="high">
@@ -51,10 +51,10 @@
   {
     "@context":"https://schema.org",
     "@type":"Organization",
-    "name":"BERA clothing",
-    "url":"https://www.beraclothing.store/",
-    "logo":"https://www.beraclothing.store/assets/images/logoo.jpeg",
-    "sameAs":[ "https://instagram.com/beraclothingg" ]
+    "name":"Viviana Varacca Boutique",
+    "url":"https://www.vivianavaraccaboutique.com/",
+    "logo":"https://www.vivianavaraccaboutique.com/assets/images/logoo.jpeg",
+    "sameAs":[ "https://instagram.com/vivianavaracca.boutique" ]
   }
   </script>
 
@@ -63,10 +63,10 @@
   {
     "@context":"https://schema.org",
     "@type":"WebSite",
-    "url":"https://www.beraclothing.store/",
+    "url":"https://www.vivianavaraccaboutique.com/",
     "potentialAction":{
       "@type":"SearchAction",
-      "target":"https://www.beraclothing.store/proximamente.html?q={search_term_string}",
+      "target":"https://www.vivianavaraccaboutique.com/proximamente.html?q={search_term_string}",
       "query-input":"required name=search_term_string"
     }
   }
@@ -125,14 +125,14 @@
       <div class="site-branding">
         <a href="index.html" class="logo-link" aria-label="Inicio">
           <div class="logo-wrap">
-            <img src="assets/images/logoo.jpeg" alt="Logo BERA clothing" class="logo" width="60" height="60" decoding="async" fetchpriority="high" />
+            <img src="assets/images/logoo.jpeg" alt="Logo Viviana Varacca Boutique" class="logo" width="60" height="60" decoding="async" fetchpriority="high" />
           </div>
         </a>
-        <div class="site-title" aria-label="BERA CLOTHING">
-          <span class="title-bera">BERA</span>
-          <span class="title-clothing">CLOTHING</span>
+        <div class="site-title" aria-label="VIVIANA VARACCA BOUTIQUE">
+          <span class="title-bera">VIVIANA</span>
+          <span class="title-clothing">BOUTIQUE</span>
         </div>
-        <span class="site-tagline">BY FRIAS</span>
+        <span class="site-tagline">VIVIANAVARACCA.BOUTIQUE</span>
       </div>
 
       <button class="hamburger nav-toggle" type="button"
@@ -176,7 +176,7 @@
         </div>
 
         <div class="menu-media">
-          <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener">Instagram</a>
+          <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">Instagram</a>
           <a href="https://wa.me/5491123456789" target="_blank" rel="noopener">WhatsApp</a>
         </div>
       </nav>
@@ -222,7 +222,7 @@
           </dl>
         </div>
         <figure class="hero-media">
-          <img src="assets/images/IMG_7229.jpeg" alt="Editorial BERA con outfit oversize" loading="eager" decoding="async" />
+          <img src="assets/images/IMG_7229.jpeg" alt="Editorial Viviana Varacca Boutique con outfit oversize" loading="eager" decoding="async" />
         </figure>
       </div>
     </section>
@@ -231,7 +231,7 @@
       <div class="container">
         <div class="content-split">
           <div>
-            <span class="badge-inline">Why BERA</span>
+            <span class="badge-inline">Why Viviana Varacca</span>
             <h2 id="destacados-title" class="section-title" style="text-align:left;">Capsule wardrobe listo para usar</h2>
             <p>Trabajamos colecciones reducidas que combinan entre sí para que armes looks completos sin esfuerzo. Materiales comfy, colores sobrios y detalles con actitud street.</p>
             <ul class="list-check">
@@ -282,7 +282,7 @@
           </a>
           <a class="category-card" href="proximamente.html?tipo=accesorio#accesorios" style="--category-bg:url('assets/images/Gorra.png');">
             <div>
-              <h3>Accesorios BERA</h3>
+              <h3>Accesorios Viviana Varacca Boutique</h3>
               <span>Completa el look</span>
             </div>
           </a>
@@ -307,7 +307,7 @@
             <span>Denim drop</span>
           </figure>
           <figure class="lookbook-card">
-            <img src="assets/images/IMG_7221.jpeg" alt="Gorra BERA edición limitada" loading="lazy" decoding="async" />
+            <img src="assets/images/IMG_7221.jpeg" alt="Gorra Viviana Varacca Boutique edición limitada" loading="lazy" decoding="async" />
             <span>Accesorios</span>
           </figure>
         </div>
@@ -317,7 +317,7 @@
     <section id="testimonios-home" class="section surface-light home-testimonios" role="region" aria-labelledby="testimonios-home-title">
       <div class="container container-narrow">
         <h2 id="testimonios-home-title" class="section-title">Lo que dice la crew</h2>
-        <p class="reviews-intro">Opiniones reales de quienes ya se sumaron a BERA. Tus reseñas nos ayudan a mejorar cada drop.</p>
+        <p class="reviews-intro">Opiniones reales de quienes ya se sumaron a Viviana Varacca Boutique. Tus reseñas nos ayudan a mejorar cada drop.</p>
 
         <div class="testimonial-grid" data-review-list>
           <p class="empty-reviews">Todavía no hay reseñas aprobadas. Sé la primera persona en compartir tu experiencia.</p>
@@ -382,12 +382,12 @@
     <section id="club" class="section surface-muted" role="region" aria-labelledby="club-title">
       <div class="container">
         <div class="home-cta">
-        <span class="ribbon">BERA Nights</span>
+        <span class="ribbon">Viviana Nights</span>
           <h3 id="club-title">Sumate al newsletter y accedé a drops exclusivos antes que nadie</h3>
           <p>Te avisamos por mail y WhatsApp cuando subimos nuevas cápsulas, promos relámpago y re-stock de tus básicos favoritos.</p>
           <div class="cta-actions">
             <a class="btn btn-primary" href="newsletter.html">Quiero recibir las novedades</a>
-            <a class="btn btn-secondary" href="https://instagram.com/beraclothingg" target="_blank" rel="noopener noreferrer">Seguinos en Instagram</a>
+            <a class="btn btn-secondary" href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener noreferrer">Seguinos en Instagram</a>
           </div>
         </div>
       </div>
@@ -401,7 +401,7 @@
   <footer class="site-footer" role="contentinfo">
     <div class="container footer-inner">
       <p>
-        <a href="https://instagram.com/beraclothingg?utm_source=site&utm_medium=footer&utm_campaign=ig_redirect"
+        <a href="https://instagram.com/vivianavaracca.boutique?utm_source=site&utm_medium=footer&utm_campaign=ig_redirect"
            target="_blank" rel="noopener noreferrer" class="instagram-icon" aria-label="Instagram">
           <img src="assets/images/instaa.png" alt="Instagram" width="28" height="28" loading="lazy" decoding="async">
         </a>
@@ -412,10 +412,10 @@
         <a href="terminos.html">Términos de servicio</a>
       </p>
       By
-      <a href="https://instagram.com/melinaffrias" target="_blank" rel="noopener noreferrer">@melinaffrias</a>
+      <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener noreferrer">@vivianavaracca.boutique</a>
       <span>&amp;</span>
-      <a href="https://instagram.com/candelaffrias" target="_blank" rel="noopener noreferrer">@candelaffrias</a>
-      <p>© 2025 BERA clothing. Todos los derechos reservados.</p>
+      <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener noreferrer">@vivianavaracca.boutique</a>
+      <p>© 2025 Viviana Varacca Boutique. Todos los derechos reservados.</p>
       <p>
         <a href="privacidad.html">Política de privacidad</a> ·
         <a href="terminos.html">Términos de servicio</a>
@@ -457,7 +457,7 @@
         <a href="proximamente.html#bodys">Bodys</a>
       </div>
       <div class="collection-social">
-        <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener">Instagram</a>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">Instagram</a>
         <a href="https://wa.me/5491123456789" target="_blank" rel="noopener">WhatsApp</a>
       </div>
     </nav>

--- a/newsletter.html
+++ b/newsletter.html
@@ -12,8 +12,8 @@
   <meta charset="UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-  <title>BERA clothing – Novedades</title>
-  <meta name="description" content="Sumate al newsletter de BERA y recibí drops privados, beneficios y restocks antes que nadie." />
+  <title>Viviana Varacca Boutique – Novedades</title>
+  <meta name="description" content="Sumate al newsletter de Viviana Varacca Boutique y recibí drops privados, beneficios y restocks antes que nadie." />
   <meta name="color-scheme" content="light dark" />
   <meta name="format-detection" content="telephone=no" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -64,14 +64,14 @@
       <div class="site-branding">
         <a href="index.html" class="logo-link" aria-label="Inicio">
           <div class="logo-wrap">
-            <img src="assets/images/logoo.jpeg" alt="Logo BERA clothing" class="logo" width="60" height="60" decoding="async" fetchpriority="high" />
+            <img src="assets/images/logoo.jpeg" alt="Logo Viviana Varacca Boutique" class="logo" width="60" height="60" decoding="async" fetchpriority="high" />
           </div>
         </a>
-        <div class="site-title" aria-label="BERA CLOTHING">
-          <span class="title-bera">BERA</span>
-          <span class="title-clothing">CLOTHING</span>
+        <div class="site-title" aria-label="VIVIANA VARACCA BOUTIQUE">
+          <span class="title-bera">VIVIANA</span>
+          <span class="title-clothing">BOUTIQUE</span>
         </div>
-        <span class="site-tagline">BY FRIAS</span>
+        <span class="site-tagline">VIVIANAVARACCA.BOUTIQUE</span>
       </div>
 
       <button class="hamburger nav-toggle" type="button"
@@ -115,7 +115,7 @@
         </div>
 
         <div class="menu-media">
-          <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener">Instagram</a>
+          <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">Instagram</a>
           <a href="https://wa.me/5491123456789" target="_blank" rel="noopener">WhatsApp</a>
         </div>
       </nav>
@@ -133,12 +133,12 @@
     <section class="page-hero" role="region" aria-labelledby="newsletter-hero-title">
       <div class="container hero-shell">
         <div class="hero-content">
-          <span class="hero-eyebrow">BERA Novedades</span>
+          <span class="hero-eyebrow">Viviana Varacca Boutique Novedades</span>
           <h1 id="newsletter-hero-title" class="hero-title">Accedé antes a cada drop y prepará tus noches sin estrés</h1>
           <p class="hero-lead">Suscribite para recibir previews, códigos exclusivos y recordatorios de restock. En cada mail te compartimos combos listos para salir y tips de styling.</p>
           <div class="hero-actions">
             <a class="btn btn-primary" data-scroll="#newsletter-form-section" href="#newsletter-form-section">Quiero suscribirme</a>
-            <a class="btn btn-secondary" href="https://instagram.com/beraclothingg" target="_blank" rel="noopener noreferrer">Seguinos en Instagram</a>
+            <a class="btn btn-secondary" href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener noreferrer">Seguinos en Instagram</a>
           </div>
           <dl class="hero-metrics">
             <div class="metric-card">
@@ -156,7 +156,7 @@
           </dl>
         </div>
         <figure class="hero-media">
-          <img src="assets/images/IMG_7231.jpeg" alt="Moodboard BERA newsletter" loading="lazy" decoding="async" />
+          <img src="assets/images/IMG_7231.jpeg" alt="Moodboard Viviana Varacca Boutique newsletter" loading="lazy" decoding="async" />
         </figure>
       </div>
     </section>
@@ -185,7 +185,7 @@
       <div class="container container-narrow">
         <div class="glass-card newsletter-card">
           <h2 id="newsletter-title" class="section-title" style="text-align:left;">Sumate al mailing</h2>
-          <p class="newsletter-intro">Dejanos tu correo y recibí en primicia el próximo drop, styling tips y acceso a BERA Rewards.</p>
+          <p class="newsletter-intro">Dejanos tu correo y recibí en primicia el próximo drop, styling tips y acceso a Viviana Rewards.</p>
           <form class="newsletter-form" id="form-newsletter">
             <label for="nl-email" class="visually-hidden">Tu email</label>
             <input id="nl-email" type="email" name="email" placeholder="tu@email.com" autocomplete="email" required>
@@ -202,7 +202,7 @@
   <footer class="site-footer" role="contentinfo">
     <div class="container footer-inner">
       <p>
-        <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener" class="instagram-icon" aria-label="Instagram">
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener" class="instagram-icon" aria-label="Instagram">
           <img src="assets/images/instaa.png" alt="Instagram" width="28" height="28" loading="lazy" decoding="async">
         </a>
         | Shop online 24/7 | Retiro en local | Berazategui centro
@@ -212,9 +212,9 @@
         <a href="terminos.html">Términos de servicio</a>
       </p>
       By
-        <a href="https://instagram.com/melinaffrias" target="_blank" rel="noopener">@melinaffrias</a> <span>&amp;</span>
-        <a href="https://instagram.com/candelaffrias" target="_blank" rel="noopener">@candelaffrias</a>
-      <p>© 2025 BERA clothing. Todos los derechos reservados.</p>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">@vivianavaracca.boutique</a> <span>&amp;</span>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">@vivianavaracca.boutique</a>
+      <p>© 2025 Viviana Varacca Boutique. Todos los derechos reservados.</p>
     </div>
   </footer>
 
@@ -251,14 +251,14 @@
         <a href="proximamente.html#bodys">Bodys</a>
       </div>
       <div class="collection-social">
-        <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener">Instagram</a>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">Instagram</a>
         <a href="https://wa.me/5491123456789" target="_blank" rel="noopener">WhatsApp</a>
       </div>
     </nav>
   </aside>
   <noscript>
     <div style="background:#111;color:#fff;padding:1rem;text-align:center;">
-      Activa JavaScript para completar la suscripción o escribinos a <a href="mailto:hola@beraclothing.com" style="color:#e91e63;">hola@beraclothing.com</a>.
+      Activa JavaScript para completar la suscripción o escribinos a <a href="mailto:hola@vivianavaraccaboutique.com" style="color:#e91e63;">hola@vivianavaraccaboutique.com</a>.
     </div>
   </noscript>
 

--- a/next/README.md
+++ b/next/README.md
@@ -1,4 +1,4 @@
-# BERA Clothing
+# Viviana Varacca Boutique
 
 Proyecto de e-commerce basado en Next.js 14.
 

--- a/next/public/manifest.json
+++ b/next/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "BERA Clothing",
-  "short_name": "BERA",
+  "name": "Viviana Varacca Boutique",
+  "short_name": "VIVIANA",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",

--- a/next/src/app/layout.tsx
+++ b/next/src/app/layout.tsx
@@ -9,8 +9,8 @@ const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
 
 export const metadata: Metadata = {
   title: {
-    default: 'BERA Clothing',
-    template: '%s | BERA Clothing'
+    default: 'Viviana Varacca Boutique',
+    template: '%s | Viviana Varacca Boutique'
   },
   description: 'Tienda online de indumentaria urbana.'
 };
@@ -21,7 +21,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body className="min-h-screen font-sans antialiased bg-white text-gray-900">
         <header className="border-b sticky top-0 bg-white z-50">
           <nav className="max-w-7xl mx-auto flex items-center justify-between p-4">
-            <Link href="/" className="text-lg font-bold">BERA</Link>
+            <Link href="/" className="text-lg font-bold">VIVIANA</Link>
             <div className="flex items-center gap-4">
               <Link href="/products" className="text-sm">Catálogo</Link>
               <DarkModeToggle />
@@ -30,7 +30,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         </header>
         {children}
         <footer className="border-t mt-10 p-4 text-center text-sm">
-          &copy; {new Date().getFullYear()} BERA Clothing.
+          &copy; {new Date().getFullYear()} Viviana Varacca Boutique.
         </footer>
         <script
           dangerouslySetInnerHTML={{

--- a/nosotros.html
+++ b/nosotros.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>BERA clothing – Sobre nosotras</title>
-  <meta name="description" content="Conocé a Melina y Candela Frías, la dupla detrás de BERA clothing. Moda urbana desde Berazategui para todo el país." />
+  <title>Viviana Varacca Boutique – Sobre nosotras</title>
+  <meta name="description" content="Conocé a Melina y Candela Frías, la dupla detrás de Viviana Varacca Boutique. Moda urbana desde Berazategui para todo el país." />
   <meta name="theme-color" content="#e91e63">
   <link rel="icon" href="assets/images/favicon.ico" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -48,14 +48,14 @@
       <div class="site-branding">
         <a href="index.html" class="logo-link" aria-label="Inicio">
           <div class="logo-wrap">
-            <img src="assets/images/logoo.jpeg" alt="Logo BERA clothing" class="logo" width="60" height="60" decoding="async" />
+            <img src="assets/images/logoo.jpeg" alt="Logo Viviana Varacca Boutique" class="logo" width="60" height="60" decoding="async" />
           </div>
         </a>
-        <div class="site-title" aria-label="BERA CLOTHING">
-          <span class="title-bera">BERA</span>
-          <span class="title-clothing">CLOTHING</span>
+        <div class="site-title" aria-label="VIVIANA VARACCA BOUTIQUE">
+          <span class="title-bera">VIVIANA</span>
+          <span class="title-clothing">BOUTIQUE</span>
         </div>
-        <span class="site-tagline">BY FRIAS</span>
+        <span class="site-tagline">VIVIANAVARACCA.BOUTIQUE</span>
       </div>
 
       <button class="hamburger nav-toggle" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Abrir menú">
@@ -96,7 +96,7 @@
         </div>
 
         <div class="menu-media">
-          <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener">Instagram</a>
+          <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">Instagram</a>
           <a href="https://wa.me/5491123456789" target="_blank" rel="noopener">WhatsApp</a>
         </div>
       </nav>
@@ -116,7 +116,7 @@
         <div class="hero-content">
           <span class="hero-eyebrow">Nuestra historia</span>
           <h1 id="about-hero-title" class="hero-title">Somos Melina y Candela Frías, dos hermanas obsesionadas con el streetwear</h1>
-          <p class="hero-lead">BERA nació en 2024 como un showroom casero en Berazategui y hoy es un proyecto omnicanal con drops limitados, colaboraciones con artistas locales y comunidad digital.</p>
+          <p class="hero-lead">Viviana Varacca Boutique nació en 2024 como un showroom casero en Berazategui y hoy es un proyecto omnicanal con drops limitados, colaboraciones con artistas locales y comunidad digital.</p>
           <div class="hero-badges">
             <span class="hero-badge">Women-led brand</span>
             <span class="hero-badge">Producción consciente</span>
@@ -160,7 +160,7 @@
 
     <section class="section surface-muted timeline-section" role="region" aria-labelledby="timeline-title">
       <div class="container">
-        <h2 id="timeline-title" class="section-title">Timeline BERA</h2>
+        <h2 id="timeline-title" class="section-title">Timeline Viviana Varacca Boutique</h2>
         <div class="timeline">
           <article class="timeline-item">
             <span class="timeline-bullet">2024</span>
@@ -193,7 +193,7 @@
   <footer class="site-footer" role="contentinfo">
     <div class="container footer-inner">
       <p>
-        <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener" class="instagram-icon" aria-label="Instagram">
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener" class="instagram-icon" aria-label="Instagram">
           <img src="assets/images/instaa.png" alt="Instagram">
         </a>
         | Shop online 24/7 | Envíos a todo el país | Berazategui centro
@@ -203,9 +203,9 @@
         <a href="terminos.html">Términos de servicio</a>
       </p>
       By
-        <a href="https://instagram.com/melinaffrias" target="_blank" rel="noopener">@melinaffrias</a> <span>&amp;</span>
-        <a href="https://instagram.com/candelaffrias" target="_blank" rel="noopener">@candelaffrias</a>
-      <p>© 2025 BERA clothing. Todos los derechos reservados.</p>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">@vivianavaracca.boutique</a> <span>&amp;</span>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">@vivianavaracca.boutique</a>
+      <p>© 2025 Viviana Varacca Boutique. Todos los derechos reservados.</p>
     </div>
   </footer>
 
@@ -242,7 +242,7 @@
         <a href="proximamente.html#bodys">Bodys</a>
       </div>
       <div class="collection-social">
-        <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener">Instagram</a>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">Instagram</a>
         <a href="https://wa.me/5491123456789" target="_blank" rel="noopener">WhatsApp</a>
       </div>
     </nav>

--- a/privacidad.html
+++ b/privacidad.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <title>Política de Privacidad – BERA clothing</title>
-  <meta name="description" content="Conocé cómo BERA clothing protege tus datos, qué información reunimos y cómo podés ejercer tus derechos." />
+  <title>Política de Privacidad – Viviana Varacca Boutique</title>
+  <meta name="description" content="Conocé cómo Viviana Varacca Boutique protege tus datos, qué información reunimos y cómo podés ejercer tus derechos." />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body class="legal-page">
@@ -12,12 +12,12 @@
     <div class="container legal-header-inner">
       <a class="logo-link" href="index.html" aria-label="Volver al inicio">
         <div class="logo-wrap">
-          <img src="assets/images/logoo.jpeg" alt="Logo BERA clothing" width="60" height="60" />
+          <img src="assets/images/logoo.jpeg" alt="Logo Viviana Varacca Boutique" width="60" height="60" />
         </div>
       </a>
-      <div class="site-title" aria-label="BERA CLOTHING">
-        <span class="title-bera">BERA</span>
-        <span class="title-clothing">CLOTHING</span>
+      <div class="site-title" aria-label="VIVIANA VARACCA BOUTIQUE">
+        <span class="title-bera">VIVIANA</span>
+        <span class="title-clothing">BOUTIQUE</span>
       </div>
       <nav class="legal-nav" aria-label="Secciones legales">
         <a href="terminos.html">Términos de servicio</a>
@@ -29,7 +29,7 @@
   <main id="main-content" class="legal-main" role="main">
     <article class="legal-article">
       <header class="legal-article__head">
-        <span class="legal-eyebrow">BERA clothing</span>
+        <span class="legal-eyebrow">Viviana Varacca Boutique</span>
         <h1 class="section-title">Política de Privacidad</h1>
         <p class="legal-updated">Última actualización: Septiembre 2025</p>
       </header>
@@ -37,7 +37,7 @@
       <ol class="legal-list">
         <li>
           <h2>Quiénes somos</h2>
-          <p>BERA clothing ("BERA", "nosotros") es una marca independiente con tienda online en <a href="https://www.beraclothing.store">beraclothing.store</a>. Podés escribirnos a <a href="mailto:hola@beraclothing.store">hola@beraclothing.store</a>.</p>
+          <p>Viviana Varacca Boutique ("Viviana Varacca Boutique", "nosotros") es una marca independiente con tienda online en <a href="https://www.vivianavaraccaboutique.com">vivianavaraccaboutique.com</a>. Podés escribirnos a <a href="mailto:hola@vivianavaraccaboutique.com">hola@vivianavaraccaboutique.com</a>.</p>
         </li>
         <li>
           <h2>Información que recopilamos</h2>
@@ -79,7 +79,7 @@
         </li>
         <li>
           <h2>Tus derechos</h2>
-          <p>Podés solicitar acceso, actualización, portabilidad o eliminación escribiendo a <a href="mailto:hola@beraclothing.store">hola@beraclothing.store</a>. Cada email promocional incluye un enlace para desuscribirse.</p>
+          <p>Podés solicitar acceso, actualización, portabilidad o eliminación escribiendo a <a href="mailto:hola@vivianavaraccaboutique.com">hola@vivianavaraccaboutique.com</a>. Cada email promocional incluye un enlace para desuscribirse.</p>
         </li>
         <li>
           <h2>Seguridad</h2>
@@ -91,7 +91,7 @@
         </li>
         <li>
           <h2>Contacto</h2>
-          <p>Si tenés preguntas o querés ejercer tus derechos, escribinos a <a href="mailto:hola@beraclothing.store">hola@beraclothing.store</a>.</p>
+          <p>Si tenés preguntas o querés ejercer tus derechos, escribinos a <a href="mailto:hola@vivianavaraccaboutique.com">hola@vivianavaraccaboutique.com</a>.</p>
         </li>
       </ol>
     </article>
@@ -99,7 +99,7 @@
 
   <footer class="site-footer" role="contentinfo">
     <div class="container footer-inner">
-      <p>© 2025 BERA clothing. Todos los derechos reservados.</p>
+      <p>© 2025 Viviana Varacca Boutique. Todos los derechos reservados.</p>
       <p class="legal-links">
         <a href="privacidad.html">Política de privacidad</a> ·
         <a href="terminos.html">Términos de servicio</a>

--- a/productos.html
+++ b/productos.html
@@ -11,19 +11,19 @@
   </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>BERA clothing – Productos</title>
+  <title>Viviana Varacca Boutique – Productos</title>
   <meta name="description" content="Explora nuestra colección completa de ropa y accesorios urbanos. Ordená por categoría o precio y encontrá tu próximo outfit." />
   <meta name="theme-color" content="#e91e63" />
-  <link rel="canonical" href="https://www.beraclothing.store/productos.html" />
+  <link rel="canonical" href="https://www.vivianavaraccaboutique.com/productos.html" />
   <meta property="og:type" content="website">
-  <meta property="og:title" content="BERA clothing – Productos">
+  <meta property="og:title" content="Viviana Varacca Boutique – Productos">
   <meta property="og:description" content="Explora nuestra colección completa de ropa y accesorios urbanos.">
-  <meta property="og:url" content="https://www.beraclothing.store/productos.html">
-  <meta property="og:image" content="https://www.beraclothing.store/assets/og/bera-products.jpg">
+  <meta property="og:url" content="https://www.vivianavaraccaboutique.com/productos.html">
+  <meta property="og:image" content="https://www.vivianavaraccaboutique.com/assets/og/viviana-varacca-products.jpg">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="BERA clothing – Productos">
+  <meta name="twitter:title" content="Viviana Varacca Boutique – Productos">
   <meta name="twitter:description" content="Explora nuestra colección completa de ropa y accesorios urbanos.">
-  <meta name="twitter:image" content="https://www.beraclothing.store/assets/og/bera-products.jpg">
+  <meta name="twitter:image" content="https://www.vivianavaraccaboutique.com/assets/og/viviana-varacca-products.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
@@ -71,14 +71,14 @@
       <div class="site-branding">
         <a href="index.html" class="logo-link" aria-label="Inicio">
           <div class="logo-wrap">
-            <img src="assets/images/logoo.jpeg" alt="Logo BERA clothing" class="logo" width="60" height="60" decoding="async" />
+            <img src="assets/images/logoo.jpeg" alt="Logo Viviana Varacca Boutique" class="logo" width="60" height="60" decoding="async" />
           </div>
         </a>
-        <div class="site-title" aria-label="BERA CLOTHING">
-          <span class="title-bera">BERA</span>
-          <span class="title-clothing">CLOTHING</span>
+        <div class="site-title" aria-label="VIVIANA VARACCA BOUTIQUE">
+          <span class="title-bera">VIVIANA</span>
+          <span class="title-clothing">BOUTIQUE</span>
         </div>
-        <span class="site-tagline">BY FRIAS</span>
+        <span class="site-tagline">VIVIANAVARACCA.BOUTIQUE</span>
       </div>
 
       <button class="hamburger nav-toggle" type="button"
@@ -122,7 +122,7 @@
         </div>
 
         <div class="menu-media">
-          <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener">Instagram</a>
+          <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">Instagram</a>
           <a href="https://wa.me/5491123456789" target="_blank" rel="noopener">WhatsApp</a>
         </div>
       </nav>
@@ -130,7 +130,7 @@
   </header>
 
   <main id="main-content">
-    <h1 class="visually-hidden">Productos – BERA clothing</h1>
+    <h1 class="visually-hidden">Productos – Viviana Varacca Boutique</h1>
     <section class="productos-hero" role="region" aria-labelledby="hero-title">
       <div class="container">
         <h2 id="hero-title" class="hero-title">Descubrí nuestra colección</h2>
@@ -392,7 +392,7 @@
   <footer class="site-footer" role="contentinfo">
     <div class="container footer-inner">
       <p>
-        <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener noreferrer" class="instagram-icon" aria-label="Instagram">
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener noreferrer" class="instagram-icon" aria-label="Instagram">
           <img src="assets/images/instaa.png" alt="Instagram">
         </a>
         | Shop online 24/7 | Envíos a todo el país | Berazategui centro
@@ -402,9 +402,9 @@
         <a href="terminos.html">Términos de servicio</a>
       </p>
       By 
-        <a href="https://instagram.com/melinaffrias" target="_blank" rel="noopener noreferrer" >@melinaffrias</a> <span>&</span>
-        <a href="https://instagram.com/candelaffrias" target="_blank" rel="noopener noreferrer" >@candelaffrias</a>
-      <p>© 2025 BERA clothing. Todos los derechos reservados.</p>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener noreferrer" >@vivianavaracca.boutique</a> <span>&</span>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener noreferrer" >@vivianavaracca.boutique</a>
+      <p>© 2025 Viviana Varacca Boutique. Todos los derechos reservados.</p>
     </div>
   </footer>
 
@@ -471,7 +471,7 @@
         <a href="#bodys">Bodys</a>
       </div>
       <div class="collection-social">
-        <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener">Instagram</a>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">Instagram</a>
         <a href="https://wa.me/5491123456789" target="_blank" rel="noopener">WhatsApp</a>
       </div>
     </nav>

--- a/proximamente.html
+++ b/proximamente.html
@@ -15,15 +15,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <title>BERA Clothing — Próximamente</title>
-  <meta name="description" content="Estamos subiendo la nueva colección BERA. Suscribite para recibir el drop apenas salga y mirá adelantos del lookbook." />
-  <meta property="og:site_name" content="BERA Clothing" />
-  <meta property="og:title" content="BERA Clothing — Próximamente" />
+  <title>Viviana Varacca Boutique — Próximamente</title>
+  <meta name="description" content="Estamos subiendo la nueva colección Viviana Varacca Boutique. Suscribite para recibir el drop apenas salga y mirá adelantos del lookbook." />
+  <meta property="og:site_name" content="Viviana Varacca Boutique" />
+  <meta property="og:title" content="Viviana Varacca Boutique — Próximamente" />
   <meta property="og:description" content="Pronto habilitamos el catálogo completo en la web. Seguinos para ver los drops antes que nadie." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="assets/images/logoo.jpeg" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="BERA Clothing — Próximamente" />
+  <meta name="twitter:title" content="Viviana Varacca Boutique — Próximamente" />
   <meta name="twitter:description" content="Pronto habilitamos el catálogo completo en la web. Seguinos para ver los drops antes que nadie." />
   <meta name="twitter:image" content="assets/images/logoo.jpeg" />
   <meta name="color-scheme" content="dark light" />
@@ -76,14 +76,14 @@
       <div class="site-branding">
         <a href="index.html" class="logo-link" aria-label="Inicio">
           <div class="logo-wrap">
-            <img src="assets/images/logoo.jpeg" alt="Logo BERA clothing" class="logo" width="60" height="60" decoding="async" fetchpriority="high" />
+            <img src="assets/images/logoo.jpeg" alt="Logo Viviana Varacca Boutique" class="logo" width="60" height="60" decoding="async" fetchpriority="high" />
           </div>
         </a>
-        <div class="site-title" aria-label="BERA CLOTHING">
-          <span class="title-bera">BERA</span>
-          <span class="title-clothing">CLOTHING</span>
+        <div class="site-title" aria-label="VIVIANA VARACCA BOUTIQUE">
+          <span class="title-bera">VIVIANA</span>
+          <span class="title-clothing">BOUTIQUE</span>
         </div>
-        <span class="site-tagline">BY FRIAS</span>
+        <span class="site-tagline">VIVIANAVARACCA.BOUTIQUE</span>
       </div>
 
       <button class="hamburger nav-toggle" type="button"
@@ -127,7 +127,7 @@
         </div>
 
         <div class="menu-media">
-          <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener">Instagram</a>
+          <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">Instagram</a>
           <a href="https://wa.me/5491123456789" target="_blank" rel="noopener">WhatsApp</a>
         </div>
       </nav>
@@ -149,7 +149,7 @@
           <h1 id="soon-title" class="hero-title">Estamos afinando los últimos detalles del catálogo digital</h1>
           <p class="hero-lead">Mientras terminamos de subir fotos y filtros, podés mirar el lookbook adelantado y reservar tus prendas por Instagram. Te damos prioridad en el próximo drop.</p>
           <div class="hero-actions">
-            <a class="btn btn-primary" href="https://instagram.com/beraclothingg" target="_blank" rel="noopener noreferrer">Abrir Instagram</a>
+            <a class="btn btn-primary" href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener noreferrer">Abrir Instagram</a>
             <a class="btn btn-secondary" data-scroll="#preview" href="#preview">Ver adelantos</a>
           </div>
           <dl class="hero-metrics">
@@ -168,7 +168,7 @@
           </dl>
         </div>
         <figure class="hero-media">
-          <img src="assets/images/IMG_7236.jpeg" alt="Editorial BERA cápsula SS25" loading="lazy" decoding="async" />
+          <img src="assets/images/IMG_7236.jpeg" alt="Editorial Viviana Varacca Boutique cápsula SS25" loading="lazy" decoding="async" />
         </figure>
       </div>
     </section>
@@ -223,7 +223,7 @@
   <footer class="site-footer" role="contentinfo">
     <div class="container footer-inner">
       <p>
-        <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener" class="instagram-icon" aria-label="Instagram">
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener" class="instagram-icon" aria-label="Instagram">
           <img src="assets/images/instaa.png" alt="Instagram" width="28" height="28" loading="lazy" decoding="async">
         </a>
         | Shop online 24/7 | Retiro en local | Berazategui centro
@@ -233,9 +233,9 @@
         <a href="terminos.html">Términos de servicio</a>
       </p>
       By
-        <a href="https://instagram.com/melinaffrias" target="_blank" rel="noopener">@melinaffrias</a> <span>&amp;</span>
-        <a href="https://instagram.com/candelaffrias" target="_blank" rel="noopener">@candelaffrias</a>
-      <p>© 2025 BERA clothing. Todos los derechos reservados.</p>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">@vivianavaracca.boutique</a> <span>&amp;</span>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">@vivianavaracca.boutique</a>
+      <p>© 2025 Viviana Varacca Boutique. Todos los derechos reservados.</p>
     </div>
   </footer>
 
@@ -272,7 +272,7 @@
         <a href="proximamente.html#bodys">Bodys</a>
       </div>
       <div class="collection-social">
-        <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener">Instagram</a>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">Instagram</a>
         <a href="https://wa.me/5491123456789" target="_blank" rel="noopener">WhatsApp</a>
       </div>
     </nav>
@@ -280,7 +280,7 @@
 
   <noscript>
     <div style="background:#111;color:#fff;padding:1rem;text-align:center;">
-      Podés ver nuestros productos en <a href="https://instagram.com/beraclothingg" style="color:#e91e63;">Instagram</a> mientras activás JavaScript.
+      Podés ver nuestros productos en <a href="https://instagram.com/vivianavaracca.boutique" style="color:#e91e63;">Instagram</a> mientras activás JavaScript.
     </div>
   </noscript>
 

--- a/terminos.html
+++ b/terminos.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <title>Términos de Servicio – BERA clothing</title>
-  <meta name="description" content="Condiciones de uso del sitio y compras online en BERA clothing." />
+  <title>Términos de Servicio – Viviana Varacca Boutique</title>
+  <meta name="description" content="Condiciones de uso del sitio y compras online en Viviana Varacca Boutique." />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body class="legal-page">
@@ -12,12 +12,12 @@
     <div class="container legal-header-inner">
       <a class="logo-link" href="index.html" aria-label="Volver al inicio">
         <div class="logo-wrap">
-          <img src="assets/images/logoo.jpeg" alt="Logo BERA clothing" width="60" height="60" />
+          <img src="assets/images/logoo.jpeg" alt="Logo Viviana Varacca Boutique" width="60" height="60" />
         </div>
       </a>
-      <div class="site-title" aria-label="BERA CLOTHING">
-        <span class="title-bera">BERA</span>
-        <span class="title-clothing">CLOTHING</span>
+      <div class="site-title" aria-label="VIVIANA VARACCA BOUTIQUE">
+        <span class="title-bera">VIVIANA</span>
+        <span class="title-clothing">BOUTIQUE</span>
       </div>
       <nav class="legal-nav" aria-label="Secciones legales">
         <a href="privacidad.html">Política de privacidad</a>
@@ -29,7 +29,7 @@
   <main id="main-content" class="legal-main" role="main">
     <article class="legal-article">
       <header class="legal-article__head">
-        <span class="legal-eyebrow">BERA clothing</span>
+        <span class="legal-eyebrow">Viviana Varacca Boutique</span>
         <h1 class="section-title">Términos de Servicio</h1>
         <p class="legal-updated">Última actualización: Septiembre 2025</p>
       </header>
@@ -37,7 +37,7 @@
       <ol class="legal-list">
         <li>
           <h2>Alcance</h2>
-          <p>Estos términos aplican al uso de <strong>beraclothing.store</strong> y a las operaciones comerciales que realizamos online. Al navegar o comprar aceptás estas condiciones.</p>
+          <p>Estos términos aplican al uso de <strong>vivianavaraccaboutique.com</strong> y a las operaciones comerciales que realizamos online. Al navegar o comprar aceptás estas condiciones.</p>
         </li>
         <li>
           <h2>Productos y precios</h2>
@@ -64,16 +64,16 @@
           <ul>
             <li>Tenés 7 días corridos desde la recepción para solicitar cambios por talle o defectos.</li>
             <li>Las prendas deben estar sin uso, con etiquetas y empaques originales.</li>
-            <li>Escribinos a <a href="mailto:hola@beraclothing.store">hola@beraclothing.store</a> para coordinar el proceso.</li>
+            <li>Escribinos a <a href="mailto:hola@vivianavaraccaboutique.com">hola@vivianavaraccaboutique.com</a> para coordinar el proceso.</li>
           </ul>
         </li>
         <li>
           <h2>Contenido generado por usuarios</h2>
-          <p>Las reseñas y comentarios enviados pueden publicarse en el sitio y redes sociales. BERA se reserva el derecho de moderar o eliminar contenido ofensivo, spam o que infrinja estos términos.</p>
+          <p>Las reseñas y comentarios enviados pueden publicarse en el sitio y redes sociales. Viviana Varacca Boutique se reserva el derecho de moderar o eliminar contenido ofensivo, spam o que infrinja estos términos.</p>
         </li>
         <li>
           <h2>Propiedad intelectual</h2>
-          <p>Todo el contenido (textos, logos, imágenes, diseños) pertenece a BERA clothing o se usa con autorización. Está prohibida su reproducción comercial sin permiso escrito.</p>
+          <p>Todo el contenido (textos, logos, imágenes, diseños) pertenece a Viviana Varacca Boutique o se usa con autorización. Está prohibida su reproducción comercial sin permiso escrito.</p>
         </li>
         <li>
           <h2>Disponibilidad del servicio</h2>
@@ -81,7 +81,7 @@
         </li>
         <li>
           <h2>Limitación de responsabilidad</h2>
-          <p>BERA no es responsable por daños indirectos, lucro cesante, uso indebido de los productos ni por demoras atribuibles a terceros proveedores de logística o pago.</p>
+          <p>Viviana Varacca Boutique no es responsable por daños indirectos, lucro cesante, uso indebido de los productos ni por demoras atribuibles a terceros proveedores de logística o pago.</p>
         </li>
         <li>
           <h2>Datos personales</h2>
@@ -93,7 +93,7 @@
         </li>
         <li>
           <h2>Contacto</h2>
-          <p>Si tenés dudas o reclamos, escribinos a <a href="mailto:hola@beraclothing.store">hola@beraclothing.store</a>.</p>
+          <p>Si tenés dudas o reclamos, escribinos a <a href="mailto:hola@vivianavaraccaboutique.com">hola@vivianavaraccaboutique.com</a>.</p>
         </li>
       </ol>
     </article>
@@ -101,7 +101,7 @@
 
   <footer class="site-footer" role="contentinfo">
     <div class="container footer-inner">
-      <p>© 2025 BERA clothing. Todos los derechos reservados.</p>
+      <p>© 2025 Viviana Varacca Boutique. Todos los derechos reservados.</p>
       <p class="legal-links">
         <a href="privacidad.html">Política de privacidad</a> ·
         <a href="terminos.html">Términos de servicio</a>

--- a/testimonios.html
+++ b/testimonios.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>BERA clothing – Testimonios</title>
-  <meta name="description" content="La crew BERA opina: reseñas reales de clientas que ya probaron nuestros drops." />
+  <title>Viviana Varacca Boutique – Testimonios</title>
+  <meta name="description" content="La crew Viviana Varacca Boutique opina: reseñas reales de clientas que ya probaron nuestros drops." />
   <meta name="theme-color" content="#e91e63">
   <link rel="icon" href="assets/images/favicon.ico" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -48,14 +48,14 @@
       <div class="site-branding">
         <a href="index.html" class="logo-link" aria-label="Inicio">
           <div class="logo-wrap">
-            <img src="assets/images/logoo.jpeg" alt="Logo BERA clothing" class="logo" width="60" height="60" decoding="async" />
+            <img src="assets/images/logoo.jpeg" alt="Logo Viviana Varacca Boutique" class="logo" width="60" height="60" decoding="async" />
           </div>
         </a>
-        <div class="site-title" aria-label="BERA CLOTHING">
-          <span class="title-bera">BERA</span>
-          <span class="title-clothing">CLOTHING</span>
+        <div class="site-title" aria-label="VIVIANA VARACCA BOUTIQUE">
+          <span class="title-bera">VIVIANA</span>
+          <span class="title-clothing">BOUTIQUE</span>
         </div>
-        <span class="site-tagline">BY FRIAS</span>
+        <span class="site-tagline">VIVIANAVARACCA.BOUTIQUE</span>
       </div>
 
       <button class="hamburger nav-toggle" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Abrir menú">
@@ -96,7 +96,7 @@
         </div>
 
         <div class="menu-media">
-          <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener">Instagram</a>
+          <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">Instagram</a>
           <a href="https://wa.me/5491123456789" target="_blank" rel="noopener">WhatsApp</a>
         </div>
       </nav>
@@ -114,7 +114,7 @@
     <section class="page-hero page-hero--compact" role="region" aria-labelledby="testimonios-title">
       <div class="container hero-shell">
         <div class="hero-content">
-          <span class="hero-eyebrow">Crew BERA</span>
+          <span class="hero-eyebrow">Crew Viviana Varacca</span>
           <h1 id="testimonios-title" class="hero-title">Historias reales de clientas que viven nuestros drops</h1>
           <p class="hero-lead">Nos importa lo que pasa después de la compra. Estas reseñas salieron de WhatsApp, Instagram y encuestas del club. Gracias por ser parte.</p>
           <div class="hero-badges">
@@ -124,7 +124,7 @@
           </div>
         </div>
         <figure class="hero-media">
-          <img src="assets/images/IMG_7238.PNG" alt="Clientas BERA" loading="lazy" decoding="async" />
+          <img src="assets/images/IMG_7238.PNG" alt="Clientas Viviana Varacca Boutique" loading="lazy" decoding="async" />
         </figure>
       </div>
     </section>
@@ -167,7 +167,7 @@
         <h2 id="cta-testimonios">¿Ya sos parte de la crew?</h2>
         <p>Si compraste un drop y querés dejar tu testimonio, escribinos por DM o completá el formulario. Tu feedback ayuda a seguir creando prendas que ames.</p>
         <div class="cta-actions">
-          <a class="btn btn-primary" href="https://instagram.com/beraclothingg" target="_blank" rel="noopener noreferrer">Enviar reseña por Instagram</a>
+          <a class="btn btn-primary" href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener noreferrer">Enviar reseña por Instagram</a>
           <a class="btn btn-secondary" href="contacto.html">Ir al formulario</a>
         </div>
       </div>
@@ -179,7 +179,7 @@
   <footer class="site-footer" role="contentinfo">
     <div class="container footer-inner">
       <p>
-        <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener" class="instagram-icon" aria-label="Instagram">
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener" class="instagram-icon" aria-label="Instagram">
           <img src="assets/images/instaa.png" alt="Instagram">
         </a>
         | Shop online 24/7 | Envíos a todo el país | Berazategui centro
@@ -189,9 +189,9 @@
         <a href="terminos.html">Términos de servicio</a>
       </p>
       By
-        <a href="https://instagram.com/melinaffrias" target="_blank" rel="noopener">@melinaffrias</a> <span>&amp;</span>
-        <a href="https://instagram.com/candelaffrias" target="_blank" rel="noopener">@candelaffrias</a>
-      <p>© 2025 BERA clothing. Todos los derechos reservados.</p>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">@vivianavaracca.boutique</a> <span>&amp;</span>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">@vivianavaracca.boutique</a>
+      <p>© 2025 Viviana Varacca Boutique. Todos los derechos reservados.</p>
     </div>
   </footer>
 
@@ -228,7 +228,7 @@
         <a href="proximamente.html#bodys">Bodys</a>
       </div>
       <div class="collection-social">
-        <a href="https://instagram.com/beraclothingg" target="_blank" rel="noopener">Instagram</a>
+        <a href="https://instagram.com/vivianavaracca.boutique" target="_blank" rel="noopener">Instagram</a>
         <a href="https://wa.me/5491123456789" target="_blank" rel="noopener">WhatsApp</a>
       </div>
     </nav>


### PR DESCRIPTION
### Motivation
- Replace the previous brand identity across the static site and Next.js scaffold so the project reflects the new name and domain.
- Update all public-facing metadata, social handles and contact points to the new brand and domain for correct SEO, sharing and communication.
- Keep existing site structure and functionality intact while applying copy and metadata updates.

### Description
- Replaced branding strings, titles and meta descriptions across the main HTML pages such as `index.html`, `contacto.html`, `productos.html`, `proximamente.html`, `newsletter.html`, `finalizarcompra.html`, `nosotros.html`, `terminos.html`, `privacidad.html` and `testimonios.html` to the new brand.
- Updated JSON-LD Organization and WebSite entries, Open Graph/Twitter meta tags, canonical URLs and OG image references to `vivianavaraccaboutique.com` and new asset paths where applicable.
- Adjusted header/footer branding including logo `alt` attributes, `site-title`/tagline text, Instagram links to `@vivianavaracca.boutique`, and contact emails to `hola@vivianavaraccaboutique.com` across pages.
- Aligned Next.js scaffold by updating `next/src/app/layout.tsx` (metadata, header label and footer copy), `next/public/manifest.json` (app name/short_name) and `next/README.md` (project title).

### Testing
- Ran `rg -n "BERA|beraclothing|melinaffrias|candelaffrias|BY FRIAS"` to locate legacy brand strings and confirm they were removed, which succeeded.
- Ran `rg -n "Viviana Varacca Boutique|vivianavaracca.boutique|VIVIANA"` to verify the new brand strings are present across the modified files, which succeeded.
- Verified repository status with `git status --short` to ensure the changes are staged/recorded in the working tree, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9217c5ca88321b8dc4115be19c5ea)